### PR TITLE
Update to MSAL.NET 3.0.3-preview

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/Controllers/HomeController.cs
+++ b/WebApp-OpenIDConnect-DotNet/Controllers/HomeController.cs
@@ -51,7 +51,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
                     .WithClientSecret(AzureAdB2COptions.ClientSecret)
                     .WithB2CAuthority(AzureAdB2COptions.Authority)
                     .Build();
-                new MSALSessionCache(signedInUserID, this.HttpContext).EnablePersistence(cca.UserTokenCache);
+                new MSALStaticCache(signedInUserID, this.HttpContext).EnablePersistence(cca.UserTokenCache);
 
                 var accounts = await cca.GetAccountsAsync();
                 AuthenticationResult result = await cca.AcquireTokenSilent(scope, accounts.FirstOrDefault())

--- a/WebApp-OpenIDConnect-DotNet/Models/StaticCache.cs
+++ b/WebApp-OpenIDConnect-DotNet/Models/StaticCache.cs
@@ -1,0 +1,75 @@
+using Microsoft.Identity.Client;
+
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using System.Collections.Generic;
+
+namespace WebApp_OpenIDConnect_DotNet.Models
+{
+    public class MSALStaticCache
+    {
+        private static Dictionary<string, byte[]> staticCache = new Dictionary<string, byte[]>();
+
+        private static ReaderWriterLockSlim SessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        string UserId = string.Empty;
+        string CacheId = string.Empty;
+        HttpContext httpContext = null;
+
+        ITokenCache cache;
+
+        public MSALStaticCache(string userId, HttpContext httpcontext)
+        {
+            // not object, we want the SUB
+            UserId = userId;
+            CacheId = UserId + "_TokenCache";
+            httpContext = httpcontext;
+        }
+
+        public ITokenCache EnablePersistence(ITokenCache cache)
+        {
+            this.cache = cache;
+            cache.SetBeforeAccess(BeforeAccessNotification);
+            cache.SetAfterAccess(AfterAccessNotification);
+            Load();
+            return cache;
+        }
+
+        public void Load()
+        {
+            SessionLock.EnterReadLock();
+            byte[] blob = staticCache.ContainsKey(CacheId) ? staticCache[CacheId] : null ;
+            if(blob != null)
+            {
+                cache.DeserializeMsalV3(blob);
+            }
+            SessionLock.ExitReadLock();
+        }
+
+        public void Persist()
+        {
+            SessionLock.EnterWriteLock();
+
+            // Reflect changes in the persistent store
+            staticCache[CacheId] = cache.SerializeMsalV3();
+            SessionLock.ExitWriteLock();
+        }
+
+        // Triggered right before MSAL needs to access the cache.
+        // Reload the cache from the persistent store in case it changed since the last access.
+        void BeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            Load();
+        }
+
+        // Triggered right after MSAL accessed the cache.
+        void AfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                Persist();
+            }
+        }
+    }
+}

--- a/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
+++ b/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
@@ -107,11 +107,17 @@ namespace WebApp_OpenIDConnect_DotNet
                 var code = context.ProtocolMessage.Code;
 
                 string signedInUserID = context.Principal.FindFirst(ClaimTypes.NameIdentifier).Value;
-                TokenCache userTokenCache = new MSALSessionCache(signedInUserID, context.HttpContext).GetMsalCacheInstance();
-                ConfidentialClientApplication cca = new ConfidentialClientApplication(AzureAdB2COptions.ClientId, AzureAdB2COptions.Authority, AzureAdB2COptions.RedirectUri, new ClientCredential(AzureAdB2COptions.ClientSecret), userTokenCache, null);
+                IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder.Create(AzureAdB2COptions.ClientId)
+                    .WithB2CAuthority(AzureAdB2COptions.Authority)
+                    .WithRedirectUri(AzureAdB2COptions.RedirectUri)
+                    .WithClientSecret(AzureAdB2COptions.ClientSecret)
+                    .Build();
+                new MSALSessionCache(signedInUserID, context.HttpContext).EnablePersistence(cca.UserTokenCache);
+
                 try
                 {
-                    AuthenticationResult result = await cca.AcquireTokenByAuthorizationCodeAsync(code, AzureAdB2COptions.ApiScopes.Split(' '));
+                    AuthenticationResult result = await cca.AcquireTokenByAuthorizationCode(AzureAdB2COptions.ApiScopes.Split(' '), code)
+                        .ExecuteAsync();
 
 
                     context.HandleCodeRedemption(result.AccessToken, result.IdToken);

--- a/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
+++ b/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
@@ -112,7 +112,7 @@ namespace WebApp_OpenIDConnect_DotNet
                     .WithRedirectUri(AzureAdB2COptions.RedirectUri)
                     .WithClientSecret(AzureAdB2COptions.ClientSecret)
                     .Build();
-                new MSALSessionCache(signedInUserID, context.HttpContext).EnablePersistence(cca.UserTokenCache);
+                new MSALStaticCache(signedInUserID, context.HttpContext).EnablePersistence(cca.UserTokenCache);
 
                 try
                 {

--- a/WebApp-OpenIDConnect-DotNet/Startup.cs
+++ b/WebApp-OpenIDConnect-DotNet/Startup.cs
@@ -19,6 +19,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
+
             Configuration = builder.Build();
         }
 
@@ -45,7 +46,8 @@ namespace WebApp_OpenIDConnect_DotNet
             services.AddSession(options =>
             {
                 options.IdleTimeout = TimeSpan.FromHours(1);
-                options.CookieHttpOnly = true;
+                options.Cookie.HttpOnly = true;
+                options.Cookie.IsEssential = true;
             });
 
             
@@ -54,6 +56,7 @@ namespace WebApp_OpenIDConnect_DotNet
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            loggerFactory.AddConsole();
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 

--- a/WebApp-OpenIDConnect-DotNet/WebApp-OpenIDConnect-DotNet.csproj
+++ b/WebApp-OpenIDConnect-DotNet/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>WebApp_OpenIDConnect_DotNet</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="2.7.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.3-preview" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.2.0" />


### PR DESCRIPTION
This is using the latest MSAL.NET API.

Like for the AAD samples the Session cache is no longer usable (need to replace it by a distributed cache).