### PR TITLE
Include ASP.NET Core in Sample Browser Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ languages:
   - csharp
 products:
   - dotnet-core
+  - aspnet-core
   - azure
   - azure-active-directory
 ---


### PR DESCRIPTION
This project contains an ASP.NET Core project however wasn't appearing when I filtered for those projects on the sample browser.